### PR TITLE
Add example ML pipelines and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-This is code used in my following book/chapter
-Liu, Y. A., & Sharma, N. (2023). Applications of Machine Learning to Optimizing Polyolefin Manufacturing. In Integrated Process Modeling, Advanced Control and Data Analytics for Optimizing Polyolefin Manufacturing (Chapter 10). Wiley-VCH GmbH. (https://doi.org/10.1002/9783527843831.ch10)
+# PolyML
+
+This repository contains example notebooks and datasets from
+**Applications of Machine Learning to Optimizing Polyolefin Manufacturing**
+(Chapter 10 of *Integrated Process Modeling, Advanced Control and Data Analytics
+for Optimizing Polyolefin Manufacturing*, Wiley–VCH, 2023).
+
+The original scripts distributed with the chapter were created for interactive
+use and are preserved here for reference. Two cleaned up examples are provided
+for quick experimentation:
+
+- `random_forest_pipeline.py` &ndash; trains a `RandomForestRegressor` on
+  `HDPE_LG_Plant_Data.csv` and reports RMSE.
+- `gradient_boosting_pipeline.py` &ndash; demonstrates a gradient boosting model
+  on the same dataset.
+
+## Setup
+
+Install the required packages and run one of the example pipelines:
+
+```bash
+pip install -r requirements.txt
+python random_forest_pipeline.py
+```
+
+The data files `HDPE_LG_Plant_Data.csv` and `Polymer_Tg_SMILES.csv` are included
+for convenience.
+
+## Citation
+
+Liu, Y. A., & Sharma, N. (2023). Applications of Machine Learning to Optimizing
+Polyolefin Manufacturing. In *Integrated Process Modeling, Advanced Control and
+Data Analytics for Optimizing Polyolefin Manufacturing* (Chapter 10). Wiley-VCH
+GmbH. <https://doi.org/10.1002/9783527843831.ch10>

--- a/gradient_boosting_pipeline.py
+++ b/gradient_boosting_pipeline.py
@@ -1,0 +1,47 @@
+"""Gradient boosting regression example using scikit-learn.
+
+This script demonstrates a modern boosting approach for predicting the HDPE
+melt index using the ``HDPE_LG_Plant_Data.csv`` dataset.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+DATA_PATH = Path(__file__).resolve().parent / "HDPE_LG_Plant_Data.csv"
+
+
+def load_data(path: Path) -> tuple[pd.DataFrame, pd.Series]:
+    df = pd.read_csv(path)
+    X = df.iloc[:, :-1]
+    y = df.iloc[:, -1]
+    return X, y
+
+
+def main() -> None:
+    X, y = load_data(DATA_PATH)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
+
+    scaler = StandardScaler().fit(X_train)
+    X_train = scaler.transform(X_train)
+    X_test = scaler.transform(X_test)
+
+    model = GradientBoostingRegressor(random_state=42)
+    model.fit(X_train, y_train)
+
+    pred_train = model.predict(X_train)
+    pred_test = model.predict(X_test)
+
+    train_rmse = mean_squared_error(y_train, pred_train, squared=False)
+    test_rmse = mean_squared_error(y_test, pred_test, squared=False)
+
+    print(f"Gradient Boosting Train RMSE: {train_rmse:.3f}")
+    print(f"Gradient Boosting Test RMSE: {test_rmse:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/random_forest_pipeline.py
+++ b/random_forest_pipeline.py
@@ -1,0 +1,49 @@
+"""Random forest regression pipeline for HDPE melt index prediction.
+
+This script provides a cleaned-up example that loads the
+``HDPE_LG_Plant_Data.csv`` data, trains a ``RandomForestRegressor`` and reports
+RMSE on the train and test sets.  It demonstrates a typical workflow for the
+data in this repository.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.metrics import mean_squared_error
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+DATA_PATH = Path(__file__).resolve().parent / "HDPE_LG_Plant_Data.csv"
+
+
+def load_data(path: Path) -> tuple[pd.DataFrame, pd.Series]:
+    """Load features ``X`` and target ``y`` from the plant data CSV."""
+    df = pd.read_csv(path)
+    X = df.iloc[:, :-1]
+    y = df.iloc[:, -1]
+    return X, y
+
+
+def main() -> None:
+    X, y = load_data(DATA_PATH)
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+    scaler = StandardScaler().fit(X_train)
+    X_train_std = scaler.transform(X_train)
+    X_test_std = scaler.transform(X_test)
+
+    model = RandomForestRegressor(random_state=0)
+    model.fit(X_train_std, y_train)
+
+    train_rmse = mean_squared_error(y_train, model.predict(X_train_std), squared=False)
+    test_rmse = mean_squared_error(y_test, model.predict(X_test_std), squared=False)
+
+    print(f"Train RMSE: {train_rmse:.3f}")
+    print(f"Test RMSE: {test_rmse:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+numpy
+pandas
+scikit-learn
+matplotlib
+seaborn
+xgboost
+tensorflow
+h2o
+autosklearn


### PR DESCRIPTION
## Summary
- expand README with running instructions
- add requirements.txt
- add cleaned up RandomForest and GradientBoosting examples

## Testing
- `python3 -m py_compile random_forest_pipeline.py gradient_boosting_pipeline.py`
- `python3 random_forest_pipeline.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687db676e9208322a42d19186027bcd6